### PR TITLE
Minor improvements

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,0 +1,41 @@
+package pasetomiddleware
+
+func Error(eh ErrorHandler) Option {
+	return func(p *PasetoMiddleware) {
+		p.ErrorHandler = eh
+	}
+}
+
+func Extractor(e TokenExtractor) Option {
+	return func(p *PasetoMiddleware) {
+		p.Extractor = e
+	}
+}
+
+func Decryptor(d TokenDecryptor) Option {
+	return func(p *PasetoMiddleware) {
+		p.Decryptor = d
+	}
+}
+
+func CredentialsOptional(o bool) Option {
+	return func(p *PasetoMiddleware) {
+		p.CredentialsOptional = o
+	}
+}
+func TokenProperty(tp string) Option {
+	return func(p *PasetoMiddleware) {
+		p.TokenProperty = tp
+	}
+}
+func FooterProperty(fp string) Option {
+	return func(p *PasetoMiddleware) {
+		p.FooterProperty = fp
+	}
+}
+
+func Debug(d bool) Option {
+	return func(p *PasetoMiddleware) {
+		p.Debug = d
+	}
+}

--- a/pasetomiddleware.go
+++ b/pasetomiddleware.go
@@ -35,8 +35,6 @@ type PasetoMiddleware struct {
 	CredentialsOptional bool
 
 	Debug bool
-
-	log.Logger
 }
 
 func (p *PasetoMiddleware) Next(handler http.Handler) http.HandlerFunc {


### PR DESCRIPTION
Removed the function `pasetomiddleware.HandlerWithNext` in favor using
simpler names: `pasetomiddleware.Next` and `pasetomiddleware.NextFunc`.
Removed `pasetomiddleware.Options` in favor of storing the settings
within the actual `PasetoMiddleware` struct itself.

Settings can be set upon creation using the functional options pattern
as described by `@davecheney` here:
https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis

I feel this should improve upon readability.